### PR TITLE
Fix warnings in glossary

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,20 +4,20 @@ This page contains a glossary of common terms and acronyms used in the neuroimag
 
 ```{glossary}
 [BIDS](https://bids.neuroimaging.io)
-	The Brain Imaging Data Structure (BIDS) consists in rules to organize and name neuroimaging and behavioral data.
+    The Brain Imaging Data Structure (BIDS) consists in rules to organize and name neuroimaging and behavioral data.
 
 [fMRI](https://en.wikipedia.org/wiki/Functional_magnetic_resonance_imaging)
-	Functional Magnetic Resonance Imaging, or functional {term}`MRI`, (fMRI) measures brain activity by detecting changes associated with blood flow. This technique relies on the fact that cerebral blood flow and neuronal activation are coupled. When an area of the brain is in use, blood flow to that region also increases.
+    Functional Magnetic Resonance Imaging, or functional {term}`MRI`, (fMRI) measures brain activity by detecting changes associated with blood flow. This technique relies on the fact that cerebral blood flow and neuronal activation are coupled. When an area of the brain is in use, blood flow to that region also increases.
 
 [FSL](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki)
-	FSL is a comprehensive library of analysis tools for FMRI, {term}`MRI` and DTI brain imaging data.
+    FSL is a comprehensive library of analysis tools for FMRI, {term}`MRI` and DTI brain imaging data.
+
+[MEG](https://en.wikipedia.org/wiki/Magnetoencephalography)
+    Magnetoencephalography (MEG) is a functional neuroimaging technique for mapping brain activity by recording magnetic fields produced by electrical currents occurring naturally in the brain, using very sensitive magnetometers.
 
 [MRI](https://en.wikipedia.org/wiki/Magnetic_resonance_imaging)
-	Magnetic Resonance Imaging (MRI) is a medical imaging technique used in radiology to form pictures of the anatomy and the physiological processes of the body.
+    Magnetic Resonance Imaging (MRI) is a medical imaging technique used in radiology to form pictures of the anatomy and the physiological processes of the body.
 
 [PET](https://en.wikipedia.org/wiki/Positron_emission_tomography)
-	Positron Emission Tomography (PET) is a functional imaging technique that uses radioactive substances known as radiotracers to visualize and measure changes in metabolic processes, and in other physiological activities including blood flow, regional chemical composition, and absorption.
-	
-[MEG](https://en.wikipedia.org/wiki/Magnetoencephalography) 
-	Magnetoencephalography (MEG) is a functional neuroimaging technique for mapping brain activity by recording magnetic fields produced by electrical currents occurring naturally in the brain, using very sensitive magnetometers.
+    Positron Emission Tomography (PET) is a functional imaging technique that uses radioactive substances known as radiotracers to visualize and measure changes in metabolic processes, and in other physiological activities including blood flow, regional chemical composition, and absorption.
 ```


### PR DESCRIPTION
Fix the following warnings:

- WARNING: glossary term must be preceded by empty line

  Required appropriate reformating of the glossary section with spaces instead of tabs, and a blank line between terms.

- WARNING: term not in glossary: MEG

  Due to an extra space character at the end of the term line.